### PR TITLE
ci: switch release bot token generation to client-id

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,9 @@ jobs:
         id: generate-token
         with:
           # uses https://github.com/organizations/tinacms/settings/apps/release-bot-allow-prs-and-push
-          app-id: ${{ secrets.BOT_APP_ID }}
+          # BOT_APP_ID holds the App's Client ID (Iv23li…), so use `client-id`. `app-id` is
+          # deprecated in v3 and rejects non-numeric values, which broke the publish job.
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_SECRET }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- The push-to-main publish job has been failing with `A JSON web token could not be decoded` ([run](https://github.com/tinacms/mongodb-level/actions/runs/25705512898)) since the `BOT_APP_ID` secret value was swapped to the App's Client ID (`Iv23li…`).
- `actions/create-github-app-token@v3`'s `app-id` input is deprecated and only accepts numeric App IDs; passing a Client ID through it yields an invalid JWT issuer claim, which is what the error reports.
- Switching to `client-id` matches the secret's current value and unblocks the changeset-driven release of the post-ESM-migration version.

Same fix as [tinacms/sqlite-level#32](https://github.com/tinacms/sqlite-level/pull/32).

## Test plan
- [ ] On merge, watch the publish job — the "Generate a token" step should succeed.
- [ ] Confirm changesets/action either opens a "Version Packages" PR or publishes a beta snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)